### PR TITLE
Move common functionality to basic.py and DigitDecompExtend to decomp.py

### DIFF
--- a/kerngen/pisa_generators/basic.py
+++ b/kerngen/pisa_generators/basic.py
@@ -283,7 +283,7 @@ class KeyMul(HighOp):
 
 
 def init_common_polys(input0: Polys, rns: int) -> Tuple[Polys, Polys, Polys]:
-    """Initialize commonly used polys in both relin and rotate kernels"""
+    """Split and extract the last part of input0 with a change of rns"""
     input_last_part = Polys.from_polys(input0, mode="last_part")
     input_last_part.name = input0.name
 

--- a/kerngen/pisa_generators/basic.py
+++ b/kerngen/pisa_generators/basic.py
@@ -252,6 +252,7 @@ class KeyMul(HighOp):
     output: Polys
     input0: Polys
     input1: KeyPolys
+    input0_fixed_part: int
 
     def to_pisa(self) -> list[PIsaOp]:
         """Return the p-isa code to perform a key multiplication"""
@@ -268,7 +269,7 @@ class KeyMul(HighOp):
                 op(
                     self.context.label,
                     self.output(part, q, unit),
-                    input0_tmp(2, q, unit),
+                    input0_tmp(self.input0_fixed_part, q, unit),
                     self.input1(digit, part, q, unit),
                     q,
                 )

--- a/kerngen/pisa_generators/basic.py
+++ b/kerngen/pisa_generators/basic.py
@@ -7,7 +7,7 @@
 
 import itertools as it
 from dataclasses import dataclass
-from typing import ClassVar, Iterable
+from typing import ClassVar, Iterable, Tuple
 from string import ascii_letters
 
 import high_parser.pisa_operations as pisa_op
@@ -279,3 +279,19 @@ class KeyMul(HighOp):
                 )
             )
         return ls
+
+
+def init_common_polys(input0: Polys, rns: int) -> Tuple[Polys, Polys, Polys]:
+    """Initialize commonly used polys in both relin and rotate kernels"""
+    input_last_part = Polys.from_polys(input0, mode="last_part")
+    input_last_part.name = input0.name
+
+    last_coeff = Polys.from_polys(input_last_part)
+    last_coeff.name = "coeffs"
+    last_coeff.rns = rns
+
+    upto_last_coeffs = Polys.from_polys(last_coeff)
+    upto_last_coeffs.parts = 1
+    upto_last_coeffs.start_parts = 0
+
+    return input_last_part, last_coeff, upto_last_coeffs

--- a/kerngen/pisa_generators/basic.py
+++ b/kerngen/pisa_generators/basic.py
@@ -282,7 +282,7 @@ class KeyMul(HighOp):
         return ls
 
 
-def init_common_polys(input0: Polys, rns: int) -> Tuple[Polys, Polys, Polys]:
+def extract_last_part_polys(input0: Polys, rns: int) -> Tuple[Polys, Polys, Polys]:
     """Split and extract the last part of input0 with a change of rns"""
     input_last_part = Polys.from_polys(input0, mode="last_part")
     input_last_part.name = input0.name

--- a/kerngen/pisa_generators/decomp.py
+++ b/kerngen/pisa_generators/decomp.py
@@ -1,0 +1,59 @@
+# Copyright (C) 2024 Intel Corporation
+# SPDX-License-Identifier: Apache-2.0
+"""Module containing digit decomposition/base extend"""
+
+from string import ascii_letters
+import itertools as it
+
+from dataclasses import dataclass
+import high_parser.pisa_operations as pisa_op
+from high_parser.pisa_operations import PIsaOp
+from high_parser import KernelContext, HighOp, Immediate, Polys
+
+from .basic import Muli, mixed_to_pisa_ops
+from .ntt import INTT, NTT
+
+
+@dataclass
+class DigitDecompExtend(HighOp):
+    """Class representing Digit decomposition and base extension"""
+
+    context: KernelContext
+    output: Polys
+    input0: Polys
+
+    def to_pisa(self) -> list[PIsaOp]:
+        """Return the p-isa code performing Digit decomposition followed by
+        base extension"""
+
+        rns_poly = Polys.from_polys(self.input0)
+        rns_poly.name = "ct"
+
+        one = Immediate(name="one")
+        r2 = Immediate(name="R2", rns=self.context.key_rns)
+
+        ls: list[pisa_op] = []
+        for input_rns_index in range(self.input0.rns):
+            ls.extend(
+                pisa_op.Muli(
+                    self.context.label,
+                    self.output(part, pq, unit),
+                    rns_poly(part, input_rns_index, unit),
+                    r2(part, pq, unit),
+                    pq,
+                )
+                for part, pq, unit in it.product(
+                    range(self.input0.start_parts, self.input0.parts),
+                    range(self.context.key_rns),
+                    range(self.context.units),
+                )
+            )
+            output_tmp = Polys.from_polys(self.output)
+            output_tmp.name += "_" + ascii_letters[input_rns_index]
+            ls.extend(NTT(self.context, output_tmp, self.output).to_pisa())
+
+        return mixed_to_pisa_ops(
+            INTT(self.context, rns_poly, self.input0),
+            Muli(self.context, rns_poly, rns_poly, one),
+            ls,
+        )

--- a/kerngen/pisa_generators/relin.py
+++ b/kerngen/pisa_generators/relin.py
@@ -1,63 +1,13 @@
 # Copyright (C) 2024 Intel Corporation
 # SPDX-License-Identifier: Apache-2.0
 
-"""Module containing relin, keymul, etc."""
-from string import ascii_letters
-import itertools as it
-
+"""Module containing relin."""
 from dataclasses import dataclass
-import high_parser.pisa_operations as pisa_op
 from high_parser.pisa_operations import PIsaOp, Comment
-from high_parser import KernelContext, HighOp, Immediate, KeyPolys, Polys
-
-from .basic import Add, Muli, KeyMul, mixed_to_pisa_ops
+from high_parser import KernelContext, HighOp, KeyPolys, Polys
+from .basic import Add, KeyMul, mixed_to_pisa_ops, init_common_polys
 from .mod import Mod
-from .ntt import INTT, NTT
-
-
-@dataclass
-class DigitDecompExtend(HighOp):
-    """Class representing Digit decomposition and base extension"""
-
-    context: KernelContext
-    output: Polys
-    input0: Polys
-
-    def to_pisa(self) -> list[PIsaOp]:
-        """Return the p-isa code performing Digit decomposition followed by
-        base extension"""
-
-        rns_poly = Polys.from_polys(self.input0)
-        rns_poly.name = "ct"
-
-        one = Immediate(name="one")
-        r2 = Immediate(name="R2", rns=self.context.key_rns)
-
-        ls: list[pisa_op] = []
-        for input_rns_index in range(self.input0.rns):
-            ls.extend(
-                pisa_op.Muli(
-                    self.context.label,
-                    self.output(part, pq, unit),
-                    rns_poly(part, input_rns_index, unit),
-                    r2(part, pq, unit),
-                    pq,
-                )
-                for part, pq, unit in it.product(
-                    range(self.input0.start_parts, self.input0.parts),
-                    range(self.context.key_rns),
-                    range(self.context.units),
-                )
-            )
-            output_tmp = Polys.from_polys(self.output)
-            output_tmp.name += "_" + ascii_letters[input_rns_index]
-            ls.extend(NTT(self.context, output_tmp, self.output).to_pisa())
-
-        return mixed_to_pisa_ops(
-            INTT(self.context, rns_poly, self.input0),
-            Muli(self.context, rns_poly, rns_poly, one),
-            ls,
-        )
+from .decomp import DigitDecompExtend
 
 
 @dataclass
@@ -82,15 +32,9 @@ class Relin(HighOp):
         mul_by_rlk = Polys("c2_rlk", parts=2, rns=self.context.key_rns)
         mul_by_rlk_modded_down = Polys.from_polys(mul_by_rlk)
         mul_by_rlk_modded_down.rns = self.input0.rns
-        input_last_part = Polys.from_polys(self.input0, mode="last_part")
-        input_last_part.name = self.input0.name
-
-        last_coeff = Polys.from_polys(input_last_part)
-        last_coeff.name = "coeffs"
-        last_coeff.rns = self.context.key_rns
-        upto_last_coeffs = Polys.from_polys(last_coeff)
-        upto_last_coeffs.parts = 1
-        upto_last_coeffs.start_parts = 0
+        input_last_part, last_coeff, upto_last_coeffs = init_common_polys(
+            self.input0, self.context.key_rns
+        )
 
         add_original = Polys.from_polys(mul_by_rlk_modded_down)
         add_original.name = self.input0.name
@@ -100,7 +44,7 @@ class Relin(HighOp):
             Comment("Digit decomposition and extend base from Q to PQ"),
             DigitDecompExtend(self.context, last_coeff, input_last_part),
             Comment("Multiply by relin key"),
-            KeyMul(self.context, mul_by_rlk, upto_last_coeffs, relin_key),
+            KeyMul(self.context, mul_by_rlk, upto_last_coeffs, relin_key, 2),
             Comment("Mod switch down to Q"),
             Mod(self.context, mul_by_rlk_modded_down, mul_by_rlk),
             Comment("Add to original poly"),

--- a/kerngen/pisa_generators/relin.py
+++ b/kerngen/pisa_generators/relin.py
@@ -5,7 +5,7 @@
 from dataclasses import dataclass
 from high_parser.pisa_operations import PIsaOp, Comment
 from high_parser import KernelContext, HighOp, KeyPolys, Polys
-from .basic import Add, KeyMul, mixed_to_pisa_ops, init_common_polys
+from .basic import Add, KeyMul, mixed_to_pisa_ops, extract_last_part_polys
 from .mod import Mod
 from .decomp import DigitDecompExtend
 
@@ -32,7 +32,7 @@ class Relin(HighOp):
         mul_by_rlk = Polys("c2_rlk", parts=2, rns=self.context.key_rns)
         mul_by_rlk_modded_down = Polys.from_polys(mul_by_rlk)
         mul_by_rlk_modded_down.rns = self.input0.rns
-        input_last_part, last_coeff, upto_last_coeffs = init_common_polys(
+        input_last_part, last_coeff, upto_last_coeffs = extract_last_part_polys(
             self.input0, self.context.key_rns
         )
 


### PR DESCRIPTION
## Proposed changes

PR to move KeyMul from relin.py to basic.py. Adds a helper function to basic.py which is used in Relin (and will be used in a future PR for Rotate). The PR also moves DigitDecompExtend to its own file, decomp.py. Further, a minor change to KeyMul & Relin to control Mul/Mac a specific part on the input. Confirmed to pass test on Relin on with 16k poly mods. 

## Types of changes

What types of changes does your code introduce to the HE Toolkit project?
_Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update (if none of the other choices apply)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating
the PR. If you are unsure about any of them, do not hesitate to ask. We are
here to help! This is simply a reminder of what we are going to look for before
merging your code._

- [x] I have read the [CONTRIBUTING](https://github.com/IntelLabs/hec-p-isa-tools/blob/main/CONTRIBUTING.md) agreement
- [x] Current formatting and unit tests / base functionality passes locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [x] I have added necessary documentation (if appropriate)
- [x] Any dependent changes have been merged and published in downstream modules

## Further comments

The PR is mainly used to organize common components and avoid code replication. 
