### PR TITLE
Tests for invalid poly order

### DIFF
--- a/kerngen/high_parser/types.py
+++ b/kerngen/high_parser/types.py
@@ -134,6 +134,11 @@ class EmptyLine(BaseModel):
     """Holder of an empty line"""
 
 
+# TODO remove hardcoding. Maybe move this to Config?
+NATIVE_POLY_SIZE = 8192
+MAX_POLY_SIZE = 131072
+
+
 class Context(BaseModel):
     """Class representing a given context of the scheme"""
 
@@ -153,6 +158,15 @@ class Context(BaseModel):
         if optional != [] and rest != []:
             raise ValueError(f"too many parameters for context given: {line}")
         int_poly_order = int(poly_order)
+        if (
+            int_poly_order < NATIVE_POLY_SIZE
+            or int_poly_order > MAX_POLY_SIZE
+            or not math.log2(int_poly_order).is_integer()
+        ):
+            raise ValueError(
+                f"Poly order `{int_poly_order}` must be power of two >= {NATIVE_POLY_SIZE} and < {MAX_POLY_SIZE}"
+            )
+
         int_max_rns = int(max_rns)
         int_key_rns = int_max_rns + int(krns) if krns else None
         return cls(
@@ -170,9 +184,7 @@ class Context(BaseModel):
     @property
     def units(self):
         """units based on 8192 ~ 8K sized polynomials"""
-        # TODO remove hardcoding. Maybe move this to Config?
-        native_poly_size = 8192
-        return max(1, self.poly_order // native_poly_size)
+        return max(1, self.poly_order // NATIVE_POLY_SIZE)
 
 
 class KernelContext(Context):

--- a/kerngen/high_parser/types.py
+++ b/kerngen/high_parser/types.py
@@ -136,6 +136,7 @@ class EmptyLine(BaseModel):
 
 # TODO remove hardcoding. Maybe move this to Config?
 NATIVE_POLY_SIZE = 8192
+MIN_POLY_SIZE = 8192
 MAX_POLY_SIZE = 131072
 
 
@@ -159,12 +160,12 @@ class Context(BaseModel):
             raise ValueError(f"too many parameters for context given: {line}")
         int_poly_order = int(poly_order)
         if (
-            int_poly_order < NATIVE_POLY_SIZE
+            int_poly_order < MIN_POLY_SIZE
             or int_poly_order > MAX_POLY_SIZE
             or not math.log2(int_poly_order).is_integer()
         ):
             raise ValueError(
-                f"Poly order `{int_poly_order}` must be power of two >= {NATIVE_POLY_SIZE} and < {MAX_POLY_SIZE}"
+                f"Poly order `{int_poly_order}` must be power of two >= {MIN_POLY_SIZE} and < {MAX_POLY_SIZE}"
             )
 
         int_max_rns = int(max_rns)

--- a/kerngen/high_parser/types.py
+++ b/kerngen/high_parser/types.py
@@ -136,7 +136,7 @@ class EmptyLine(BaseModel):
 
 # TODO remove hardcoding. Maybe move this to Config?
 NATIVE_POLY_SIZE = 8192
-MIN_POLY_SIZE = 8192
+MIN_POLY_SIZE = 16384
 MAX_POLY_SIZE = 131072
 
 

--- a/kerngen/tests/test_kerngen.py
+++ b/kerngen/tests/test_kerngen.py
@@ -98,7 +98,7 @@ def test_invalid_scheme(kerngen_path):
 
 @pytest.mark.parametrize("invalid_poly", [16000, 2**12, 2**13, 2**18])
 def test_invalid_poly_order(kerngen_path, invalid_poly):
-    """Poly order should be powers of two >= 2^13 and <= 2^17"""
+    """Poly order should be powers of two >= 2^14 and <= 2^17"""
     input_string = "CONTEXT BGV " + str(invalid_poly) + " 4 2\nADD a b c\n"
     result = execute_process(
         [kerngen_path],

--- a/kerngen/tests/test_kerngen.py
+++ b/kerngen/tests/test_kerngen.py
@@ -96,7 +96,7 @@ def test_invalid_scheme(kerngen_path):
     assert result.returncode != 0
 
 
-@pytest.mark.parametrize("invalid_poly", [16000, 2**12, 2**18])
+@pytest.mark.parametrize("invalid_poly", [16000, 2**12, 2**13, 2**18])
 def test_invalid_poly_order(kerngen_path, invalid_poly):
     """Poly order should be powers of two >= 2^13 and <= 2^17"""
     input_string = "CONTEXT BGV " + str(invalid_poly) + " 4 2\nADD a b c\n"

--- a/kerngen/tests/test_kerngen.py
+++ b/kerngen/tests/test_kerngen.py
@@ -96,7 +96,7 @@ def test_invalid_scheme(kerngen_path):
     assert result.returncode != 0
 
 
-@pytest.mark.parametrize("invalid_poly", [16000, 8000, 2**18])
+@pytest.mark.parametrize("invalid_poly", [16000, 2**12, 2**18])
 def test_invalid_poly_order(kerngen_path, invalid_poly):
     """Poly order should be powers of two >= 2^13 and <= 2^17"""
     input_string = "CONTEXT BGV " + str(invalid_poly) + " 4 2\nADD a b c\n"

--- a/kerngen/tests/test_kerngen.py
+++ b/kerngen/tests/test_kerngen.py
@@ -47,7 +47,7 @@ def test_op(kerngen_path, gen_op_data):
 def test_missing_context(kerngen_path):
     """Test kerngen raises an exception when context is not the first line of
     input"""
-    input_string = "ADD a b c\nCONTEXT BGV 8192 4\n"
+    input_string = "ADD a b c\nCONTEXT BGV 16384 4\n"
     result = execute_process(
         [kerngen_path],
         data_in=input_string,
@@ -59,7 +59,7 @@ def test_missing_context(kerngen_path):
 
 def test_multiple_contexts(kerngen_path):
     """Test kerngen raises an exception when more than one context is given"""
-    input_string = "CONTEXT BGV 8192 4\nData a 2\nCONTEXT BGV 8192 4\n"
+    input_string = "CONTEXT BGV 16384 4\nData a 2\nCONTEXT BGV 16384 4\n"
     result = execute_process(
         [kerngen_path],
         data_in=input_string,
@@ -72,7 +72,7 @@ def test_multiple_contexts(kerngen_path):
 def test_unrecognised_opname(kerngen_path):
     """Test kerngen raises an exception when receiving an unrecognised
     opname"""
-    input_string = "CONTEXT BGV 8192 4\nOPERATION a b c\n"
+    input_string = "CONTEXT BGV 16384 4\nOPERATION a b c\n"
     result = execute_process(
         [kerngen_path],
         data_in=input_string,
@@ -86,7 +86,7 @@ def test_unrecognised_opname(kerngen_path):
 
 def test_invalid_scheme(kerngen_path):
     """Test kerngen raises an exception when receiving an invalid scheme"""
-    input_string = "CONTEXT SCHEME 8192 4\nADD a b c\n"
+    input_string = "CONTEXT SCHEME 16384 4\nADD a b c\n"
     result = execute_process(
         [kerngen_path],
         data_in=input_string,
@@ -125,8 +125,8 @@ def test_parse_results_multiple_context():
     with pytest.raises(LookupError) as e:
         parse_results = ParseResults(
             [
-                Context(scheme="BGV", poly_order=8192, max_rns=1),
-                Context(scheme="CKKS", poly_order=8192, max_rns=1),
+                Context(scheme="BGV", poly_order=16384, max_rns=1),
+                Context(scheme="CKKS", poly_order=16384, max_rns=1),
             ],
             {},
         )
@@ -138,7 +138,7 @@ def test_parse_results_multiple_context():
 def fixture_gen_op_data(request):
     """Given an op name, return both the input and expected output strings"""
     in_lines = (
-        "CONTEXT BGV 8192 4",
+        "CONTEXT BGV 16384 4",
         "Data a 2",
         "Data b 2",
         "Data c 2",

--- a/kerngen/tests/test_kerngen.py
+++ b/kerngen/tests/test_kerngen.py
@@ -96,15 +96,19 @@ def test_invalid_scheme(kerngen_path):
     assert result.returncode != 0
 
 
-def test_invalid_poly_order(kerngen_path):
-    """Poly order should be powers of two >= 8k"""
-    input_string = "CONTEXT BGV 16000 4 2\nADD a b c\n"
+@pytest.mark.parametrize("invalid_poly", [16000, 8000, 2**18])
+def test_invalid_poly_order(kerngen_path, invalid_poly):
+    """Poly order should be powers of two >= 2^13 and <= 2^17"""
+    input_string = "CONTEXT BGV " + str(invalid_poly) + " 4 2\nADD a b c\n"
     result = execute_process(
         [kerngen_path],
         data_in=input_string,
     )
     assert not result.stdout
-    assert "ValueError: Poly order `16000` must be power of two >=" in result.stderr
+    assert (
+        "ValueError: Poly order `" + str(invalid_poly) + "` must be power of two >="
+        in result.stderr
+    )
     assert result.returncode != 0
 
 

--- a/kerngen/tests/test_kerngen.py
+++ b/kerngen/tests/test_kerngen.py
@@ -96,6 +96,18 @@ def test_invalid_scheme(kerngen_path):
     assert result.returncode != 0
 
 
+def test_invalid_poly_order(kerngen_path):
+    """Poly order should be powers of two >= 8k"""
+    input_string = "CONTEXT BGV 16000 4 2\nADD a b c\n"
+    result = execute_process(
+        [kerngen_path],
+        data_in=input_string,
+    )
+    assert not result.stdout
+    assert "ValueError: Poly order `16000` must be power of two >=" in result.stderr
+    assert result.returncode != 0
+
+
 def test_parse_results_missing_context():
     """Test ParseResults constructor for missing context"""
     with pytest.raises(LookupError) as e:


### PR DESCRIPTION
## Proposed changes

- Modifies high_parser/types.py, which adds min/max constants and checks for out-of-bounds or non-power of two poly order.
- Adds a new test function to test_kerngen.py to test for various invalid poly order.

## Types of changes

What types of changes does your code introduce to the HE Toolkit project?
_Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update (if none of the other choices apply)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating
the PR. If you are unsure about any of them, do not hesitate to ask. We are
here to help! This is simply a reminder of what we are going to look for before
merging your code._

- [x] I have read the [CONTRIBUTING](https://github.com/IntelLabs/hec-p-isa-tools/blob/main/CONTRIBUTING.md) agreement
- [x] Current formatting and unit tests / base functionality passes locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [x] I have added necessary documentation (if appropriate)
- [x] Any dependent changes have been merged and published in downstream modules

## Further comments

In a future PR, NATIVE_POLY_MOD, MIN_POLY_SIZE, and MAX_POLY_SIZE will be parameters that are user configurable rather than constant variables.