### PR TITLE
Bug fix for NTT Kernel

### DIFF
--- a/kerngen/pisa_generators/ntt.py
+++ b/kerngen/pisa_generators/ntt.py
@@ -90,21 +90,20 @@ class NTT(HighOp):
         # TODO We need to decide whether output symbols need to be defined
         outtmp = Polys("outtmp", self.output.parts, self.output.rns)
 
-        # control the input for the butterfly method.
+        # Essentially a scalar mul since psi 1 part
         if self.context.ntt_stages % 2 == 0:
-            # Essentially a scalar mul since psi 1 part
+            # Even case: butterfly input starts "coeff"
             mul = Mul(self.context, self.output, self.input0, psi)
-            butterfly_input = outtmp
         else:
+            # Odd case: butterfly input stats with "outtmp"
             mul = Mul(self.context, outtmp, self.input0, psi)
-            butterfly_input = self.input0
 
         butterflies = butterflies_ops(
             pisa_op.NTT,
             context=self.context,
             output=self.output,
             outtmp=outtmp,
-            input0=butterfly_input,
+            input0=self.input0,
         )
 
         return mixed_to_pisa_ops(mul, butterflies)


### PR DESCRIPTION
## Proposed changes

Fixes a bug where NTT Kernel was generating unused commands for even poly order cases. Tested for BGV 16K-128K Poly orders for NTT/INTT, Relin, & Rotate Kernels.

## Types of changes

What types of changes does your code introduce to the HE Toolkit project?
_Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update (if none of the other choices apply)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating
the PR. If you are unsure about any of them, do not hesitate to ask. We are
here to help! This is simply a reminder of what we are going to look for before
merging your code._

- [x] I have read the [CONTRIBUTING](https://github.com/IntelLabs/hec-p-isa-tools/blob/main/CONTRIBUTING.md) agreement
- [x] Current formatting and unit tests / base functionality passes locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [x] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

## Further comments

